### PR TITLE
Update 0.2_Credits.md

### DIFF
--- a/0.2_Credits.md
+++ b/0.2_Credits.md
@@ -10,11 +10,11 @@ Assistant Development: Shawn Carpenter, Jonathan Laufersweiler, James Lowder, Mi
 
 Further Development: Greg Stafford, David Dunham, Mark Galeotti, Neil Robinson, Adam RKitch, Roderick Robinson, Lawrence Whitaker,  
 
-A modified version of Chained Contests and Plot Edits from *Mythic Russia* © copyright 2006, 2010 Mark Galeotti; developed by Graham Robinson (for “Chained Contests”) appears in this game and is added as Open Game Content here with permission.
+A modified version of Chained Contests and Plot Edits from *Mythic Russia* © copyright 2006, 2010 Mark Galeotti; developed by Graham Robinson (for “Chained Contests”) appears in this game and is added as Licensed Material here with permission.
 
-Material in *Section 1, Introduction* and *Section 2, Basic Mechanics* © copyright 2018 Jonathan Laufersweiler and added as Open Game Content here with permission.
+Material in *Section 1, Introduction* and *Section 2, Basic Mechanics* © copyright 2018 Jonathan Laufersweiler and added as Licensed Material here with permission.
 
-Material in *Section 2, Basic Mechanics* © copyright 2020 Shawn Carpenter and added as Open Game Content here with permission.
+Material in *Section 2, Basic Mechanics* © copyright 2020 Shawn Carpenter and added as Licensed Material here with permission.
 
 QuestWorlds SRD with annotations for individual contributions can be found at GitHub: [https://github.com/ChaosiumInc/QuestWorlds/pulls](https://github.com/ChaosiumInc/QuestWorlds/pulls).
 


### PR DESCRIPTION
Replacing deprecated "Open Gaming Content" designations with ORC "Licensed Material" designations.